### PR TITLE
Implement BloomFilter.size() and BloomFilter.num_hashes()

### DIFF
--- a/bloom.py
+++ b/bloom.py
@@ -9,6 +9,7 @@
 
 import collections
 import functools
+import math
 import random
 import string
 
@@ -47,3 +48,21 @@ class BloomFilter(object):
         suffix = ''.join(random_char() for _ in xrange(self._RANDOM_KEY_LENGTH))
         random_key = ''.join((self._RANDOM_KEY_PREFIX, suffix))
         return random_key
+
+    def size(self):
+        '''The required number of bits (m) given n and p.
+
+        This method returns the required number of bits (m) for the underlying
+        string representing this Bloom filter given the the number of elements
+        that you expect to insert (n) and your acceptable false positive
+        probability (p).
+
+        More about the formula that this method implements:
+            https://en.wikipedia.org/wiki/Bloom_filter#Optimal_number_of_hash_functions
+        '''
+        try:
+            return self._size
+        except AttributeError:
+            self._size = -self.num_values * math.log(self.false_positives) / math.log(2)**2
+            self._size = int(math.ceil(self._size))
+            return self.size()

--- a/bloom.py
+++ b/bloom.py
@@ -66,3 +66,22 @@ class BloomFilter(object):
             self._size = -self.num_values * math.log(self.false_positives) / math.log(2)**2
             self._size = int(math.ceil(self._size))
             return self.size()
+
+    def num_hashes(self):
+        '''The number of hash functions (k) given m and n, minimizing p.
+
+        This method returns the number of times (k) to run our hash functions
+        on a given input string to compute bit offsets into the underlying
+        string representing this Bloom filter.  m is the size in bits of the
+        underlying string, n is the number of elements that you expect to
+        insert, and p is your acceptable false positive probability.
+
+        More about the formula that this method implements:
+            https://en.wikipedia.org/wiki/Bloom_filter#Optimal_number_of_hash_functions
+        '''
+        try:
+            return self._num_hashes
+        except AttributeError:
+            self._num_hashes = self.size() / self.num_values * math.log(2)
+            self._num_hashes = int(math.ceil(self._num_hashes))
+            return self.num_hashes()

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -32,3 +32,16 @@ class BloomFilterTests(unittest.TestCase):
 
         bloom_filter = BloomFilter(num_values=1000, false_positives=0.01)
         assert bloom_filter.size() == 9586
+
+    def test_num_hashes(self):
+        bloom_filter = BloomFilter(num_values=100, false_positives=0.1)
+        assert bloom_filter.num_hashes() == 3
+
+        bloom_filter = BloomFilter(num_values=100, false_positives=0.01)
+        assert bloom_filter.num_hashes() == 7
+
+        bloom_filter = BloomFilter(num_values=1000, false_positives=0.1)
+        assert bloom_filter.num_hashes() == 3
+
+        bloom_filter = BloomFilter(num_values=1000, false_positives=0.01)
+        assert bloom_filter.num_hashes() == 7

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -19,3 +19,16 @@ class BloomFilterTests(unittest.TestCase):
         assert bloom_filter.key.startswith(BloomFilter._RANDOM_KEY_PREFIX)
         assert bloom_filter.num_values == 100
         assert bloom_filter.false_positives == 0.01
+
+    def test_size(self):
+        bloom_filter = BloomFilter(num_values=100, false_positives=0.1)
+        assert bloom_filter.size() == 480
+
+        bloom_filter = BloomFilter(num_values=100, false_positives=0.01)
+        assert bloom_filter.size() == 959
+
+        bloom_filter = BloomFilter(num_values=1000, false_positives=0.1)
+        assert bloom_filter.size() == 4793
+
+        bloom_filter = BloomFilter(num_values=1000, false_positives=0.01)
+        assert bloom_filter.size() == 9586


### PR DESCRIPTION
Rather than requiring our users to specify their required _m_ (number of bits in the underlying string) and optimum _k_ (number of hash functions), I think that a better API is to have them specify their _n_ (number of values that they expect to insert) and _p_ (acceptable false positive probability) values.  Then from _n_ and _p_, we can compute _m_ and _k_.

Formulas from [Wikipedia](https://en.wikipedia.org/wiki/Bloom_filter#Optimal_number_of_hash_functions).