### PR TITLE
Implement BloomFilter._bit_offsets()

### DIFF
--- a/bloom.py
+++ b/bloom.py
@@ -9,10 +9,12 @@
 
 import collections
 import functools
+import json
 import math
 import random
 import string
 
+import mmh3
 from pymemcache.client.base import Client
 
 
@@ -85,3 +87,38 @@ class BloomFilter(object):
             self._num_hashes = self.size() / self.num_values * math.log(2)
             self._num_hashes = int(math.ceil(self._num_hashes))
             return self.num_hashes()
+
+    def _bit_offsets(self, value):
+        '''The bit offsets to set/check in this Bloom filter for a given value.
+
+        Instantiate a Bloom filter:
+
+            >>> dilberts = BloomFilter(
+            ...     num_values=100,
+            ...     false_positives=0.01,
+            ...     key='dilberts',
+            ... )
+
+        Now let's look at a few examples:
+
+            >>> tuple(dilberts._bit_offsets('rajiv'))
+            (183L, 319L, 787L, 585L, 8L, 471L, 711L)
+            >>> tuple(dilberts._bit_offsets('raj'))
+            (482L, 875L, 725L, 667L, 109L, 714L, 595L)
+            >>> tuple(dilberts._bit_offsets('dan'))
+            (687L, 925L, 954L, 707L, 615L, 914L, 620L)
+
+        Thus, if we want to insert the value 'rajiv' into our Bloom filter,
+        then we must set bits 183, 319, 787, 585, 8, 471, and 711 all to 1.  If
+        any/all of them are already 1, no problems.
+
+        Similarly, if we want to check to see if the value 'rajiv' is in our
+        Bloom filter, then we must check to see if the bits 183, 319, 787, 585,
+        8, 471, and 711 are all set to 1.  If even one of those bits is set to
+        0, then the value 'rajiv' must never have been inserted into our Bloom
+        filter.  But if all of those bits are set to 1, then the value 'rajiv'
+        was *probably* inserted into our Bloom filter.
+        '''
+        encoded_value = json.dumps(value, sort_keys=True)
+        for seed in range(self.num_hashes()):
+            yield mmh3.hash(encoded_value, seed=seed) % self.size()

--- a/bloom.py
+++ b/bloom.py
@@ -122,3 +122,18 @@ class BloomFilter(object):
         encoded_value = json.dumps(value, sort_keys=True)
         for seed in range(self.num_hashes()):
             yield mmh3.hash(encoded_value, seed=seed) % self.size()
+
+
+
+def main():                 # pragma: no cover
+    # Run the doctests in this module with:
+    #   $ source venv/bin/activate
+    #   $ python -m bloom
+    #   $ deactivate
+    import doctest
+    import sys
+    results = doctest.testmod()
+    sys.exit(bool(results.failed))
+
+if __name__ == '__main__':  # pragma: no cover
+    main()

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -1,0 +1,30 @@
+#-----------------------------------------------------------------------------#
+#   test_doctests.py                                                          #
+#                                                                             #
+#   Copyright (c) 2017, Rajiv Bakulesh Shah, original author.                 #
+#   All rights reserved.                                                      #
+#-----------------------------------------------------------------------------#
+
+
+
+import doctest
+import importlib
+import os
+import unittest
+
+
+
+class DoctestTests(unittest.TestCase):
+    def _modules(self):
+        test_dir = os.path.dirname(__file__)
+        source_dir = os.path.dirname(test_dir)
+        source_files = (f for f in os.listdir(source_dir) if f.endswith('.py'))
+        for source_file in source_files:
+            module_name = os.path.splitext(source_file)[0]
+            module = importlib.import_module(module_name)
+            yield module
+
+    def test_doctests(self):
+        for module in self._modules():
+            results = doctest.testmod(m=module)
+            assert not results.failed


### PR DESCRIPTION
This method is the beating heart of our Bloom filter.  Given a value,
compute its corresponding bit offsets within the underlying string
representing our Bloom Filter.

Next, we'll make sure that all of the bits at those offsets are set to 1
when testing for membership; and we'll set all of the bits at those
offsets to 1 when inserting.