### PR TITLE
Implement adding elements and testing membership

### DIFF
--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -15,33 +15,147 @@ from bloom import BloomFilter
 
 class BloomFilterTests(unittest.TestCase):
     def test_init(self):
-        bloom_filter = BloomFilter()
-        assert bloom_filter.key.startswith(BloomFilter._RANDOM_KEY_PREFIX)
-        assert bloom_filter.num_values == 100
-        assert bloom_filter.false_positives == 0.01
+        dilberts = BloomFilter()
+        assert dilberts.key.startswith(BloomFilter._RANDOM_KEY_PREFIX)
+        assert dilberts.num_values == 100
+        assert dilberts.false_positives == 0.01
+        assert 'rajiv' not in dilberts
+        assert 'raj' not in dilberts
+        assert 'dan' not in dilberts
+        assert 'eric' not in dilberts
+
+    def test_init_with_iterable(self):
+        dilberts = BloomFilter(
+            {'rajiv', 'raj'},
+            num_values=100,
+            false_positives=0.01,
+        )
+        assert dilberts.num_values == 100
+        assert dilberts.false_positives == 0.01
+        assert 'rajiv' in dilberts
+        assert 'raj' in dilberts
+        assert 'dan' not in dilberts
+        assert 'eric' not in dilberts
 
     def test_size(self):
-        bloom_filter = BloomFilter(num_values=100, false_positives=0.1)
-        assert bloom_filter.size() == 480
+        dilberts = BloomFilter(num_values=100, false_positives=0.1)
+        assert dilberts.size() == 480
 
-        bloom_filter = BloomFilter(num_values=100, false_positives=0.01)
-        assert bloom_filter.size() == 960
+        dilberts = BloomFilter(num_values=100, false_positives=0.01)
+        assert dilberts.size() == 960
 
-        bloom_filter = BloomFilter(num_values=1000, false_positives=0.1)
-        assert bloom_filter.size() == 4800
+        dilberts = BloomFilter(num_values=1000, false_positives=0.1)
+        assert dilberts.size() == 4800
 
-        bloom_filter = BloomFilter(num_values=1000, false_positives=0.01)
-        assert bloom_filter.size() == 9592
+        dilberts = BloomFilter(num_values=1000, false_positives=0.01)
+        assert dilberts.size() == 9592
 
     def test_num_hashes(self):
-        bloom_filter = BloomFilter(num_values=100, false_positives=0.1)
-        assert bloom_filter.num_hashes() == 3
+        dilberts = BloomFilter(num_values=100, false_positives=0.1)
+        assert dilberts.num_hashes() == 3
 
-        bloom_filter = BloomFilter(num_values=100, false_positives=0.01)
-        assert bloom_filter.num_hashes() == 7
+        dilberts = BloomFilter(num_values=100, false_positives=0.01)
+        assert dilberts.num_hashes() == 7
 
-        bloom_filter = BloomFilter(num_values=1000, false_positives=0.1)
-        assert bloom_filter.num_hashes() == 3
+        dilberts = BloomFilter(num_values=1000, false_positives=0.1)
+        assert dilberts.num_hashes() == 3
 
-        bloom_filter = BloomFilter(num_values=1000, false_positives=0.01)
-        assert bloom_filter.num_hashes() == 7
+        dilberts = BloomFilter(num_values=1000, false_positives=0.01)
+        assert dilberts.num_hashes() == 7
+
+    def test_membership(self):
+        dilberts = BloomFilter(num_values=100, false_positives=0.01)
+        assert 'rajiv' not in dilberts
+        assert 'raj' not in dilberts
+        assert 'dan' not in dilberts
+        assert 'eric' not in dilberts
+
+        dilberts.add('rajiv')
+        assert 'rajiv' in dilberts
+        assert 'raj' not in dilberts
+        assert 'dan' not in dilberts
+        assert 'eric' not in dilberts
+
+        dilberts.add('raj')
+        assert 'rajiv' in dilberts
+        assert 'raj' in dilberts
+        assert 'dan' not in dilberts
+        assert 'eric' not in dilberts
+
+        dilberts.add('rajiv')
+        assert 'rajiv' in dilberts
+        assert 'raj' in dilberts
+        assert 'dan' not in dilberts
+        assert 'eric' not in dilberts
+
+        dilberts.add('raj')
+        assert 'rajiv' in dilberts
+        assert 'raj' in dilberts
+        assert 'dan' not in dilberts
+        assert 'eric' not in dilberts
+
+        dilberts.add('dan')
+        assert 'rajiv' in dilberts
+        assert 'raj' in dilberts
+        assert 'dan' in dilberts
+        assert 'eric' not in dilberts
+
+        dilberts.add('eric')
+        assert 'rajiv' in dilberts
+        assert 'raj' in dilberts
+        assert 'dan' in dilberts
+        assert 'eric' in dilberts
+
+    def test_update(self):
+        dilberts = BloomFilter(num_values=100, false_positives=0.01)
+        assert 'rajiv' not in dilberts
+        assert 'raj' not in dilberts
+        assert 'dan' not in dilberts
+        assert 'eric' not in dilberts
+        assert 'jenny' not in dilberts
+        assert 'will' not in dilberts
+        assert 'rhodes' not in dilberts
+
+        dilberts.update({'rajiv', 'raj'}, {'dan', 'eric'})
+        assert 'rajiv' in dilberts
+        assert 'raj' in dilberts
+        assert 'dan' in dilberts
+        assert 'eric' in dilberts
+        assert 'jenny' not in dilberts
+        assert 'will' not in dilberts
+        assert 'rhodes' not in dilberts
+
+        dilberts.update({'jenny', 'will'})
+        assert 'rajiv' in dilberts
+        assert 'raj' in dilberts
+        assert 'dan' in dilberts
+        assert 'eric' in dilberts
+        assert 'jenny' in dilberts
+        assert 'will' in dilberts
+        assert 'rhodes' not in dilberts
+
+        dilberts.update(set())
+        assert 'rajiv' in dilberts
+        assert 'raj' in dilberts
+        assert 'dan' in dilberts
+        assert 'eric' in dilberts
+        assert 'jenny' in dilberts
+        assert 'will' in dilberts
+        assert 'rhodes' not in dilberts
+
+    def test_clear(self):
+        dilberts = BloomFilter(
+            {'rajiv', 'raj'},
+            num_values=100,
+            false_positives=0.01,
+        )
+        assert 'rajiv' in dilberts
+        assert 'raj' in dilberts
+        assert 'dan' not in dilberts
+        assert 'eric' not in dilberts
+
+        dilberts.clear()
+        assert 'rajiv' not in dilberts
+        assert 'raj' not in dilberts
+        assert 'dan' not in dilberts
+        assert 'eric' not in dilberts


### PR DESCRIPTION
Faithfully mirroring Python's `set` API, the methods are:

* `BloomFilter.add()` - Add an element to the Bloom filter
* `BloomFilter.update()` - Update the Bloom filter with the union of
itself and others
* `BloomFilter.__contains__()` - Test whether an element has been added
to the Bloom filter
* `BloomFilter.clear()` - Remove all elements from the Bloom filter