### PR TITLE
Use Memcache's cas command to ensure consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #-----------------------------------------------------------------------------#
 #   Makefile                                                                  #
 #                                                                             #
-#   Copyright © 2017, Rajiv Bakulesh Shah, original author.                   #
+#   Copyright (c) 2017-2018, Rajiv Bakulesh Shah, original author.            #
 #   All rights reserved.                                                      #
 #-----------------------------------------------------------------------------#
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ storage size and the element insertion/lookup time of your Bloom filter.
 
 * [Wikipedia Article](https://en.wikipedia.org/wiki/Bloom_filter)
 * [Reference Implementation](http://www.maxburstein.com/blog/creating-a-simple-bloom-filter/)
+* [Medium Post](https://blog.medium.com/what-are-bloom-filters-1ec2a50c68ff)
 
 ## Usage
 

--- a/bloom/__init__.py
+++ b/bloom/__init__.py
@@ -6,11 +6,9 @@
 #-----------------------------------------------------------------------------#
 
 
-
 from .bloom import BloomFilter
 from .exceptions import BloomFilterException
 from .exceptions import CheckAndSetError
-
 
 
 __all__ = ['BloomFilter', 'BloomFilterException', 'CheckAndSetError']

--- a/bloom/__init__.py
+++ b/bloom/__init__.py
@@ -1,7 +1,7 @@
 #-----------------------------------------------------------------------------#
 #   __init__.py                                                               #
 #                                                                             #
-#   Copyright (c) 2017, Rajiv Bakulesh Shah, original author.                 #
+#   Copyright (c) 2017-2018, Rajiv Bakulesh Shah, original author.            #
 #   All rights reserved.                                                      #
 #-----------------------------------------------------------------------------#
 

--- a/bloom/__init__.py
+++ b/bloom/__init__.py
@@ -8,7 +8,9 @@
 
 
 from .bloom import BloomFilter
+from .exceptions import BloomFilterException
+from .exceptions import CheckAndSetError
 
 
 
-__all__ = ['BloomFilter']
+__all__ = ['BloomFilter', 'BloomFilterException', 'CheckAndSetError']

--- a/bloom/bloom.py
+++ b/bloom/bloom.py
@@ -6,7 +6,6 @@
 #-----------------------------------------------------------------------------#
 
 
-
 import collections
 import functools
 import itertools
@@ -22,9 +21,7 @@ from pymemcache.client.base import Client
 from .exceptions import CheckAndSetError
 
 
-
 MemcacheServer = collections.namedtuple('MemcacheServer', ('hostname', 'port'))
-
 
 
 class BloomFilter(object):
@@ -313,7 +310,6 @@ class BloomFilter(object):
     def __repr__(self):
         'Return the string representation of a BloomFilter.  O(1)'
         return '<{} key={}>'.format(self.__class__.__name__, self.key)
-
 
 
 def main():                 # pragma: no cover

--- a/bloom/bloom.py
+++ b/bloom/bloom.py
@@ -207,7 +207,7 @@ class BloomFilter(object):
         was *probably* inserted into our Bloom filter.
         '''
         encoded_value = json.dumps(value, sort_keys=True)
-        for seed in range(self.num_hashes()):
+        for seed in xrange(self.num_hashes()):
             yield mmh3.hash(encoded_value, seed=seed) % self.size()
 
     def _load_bit_array(self):

--- a/bloom/bloom.py
+++ b/bloom/bloom.py
@@ -19,6 +19,8 @@ import mmh3
 from bitarray import bitarray
 from pymemcache.client.base import Client
 
+from .exceptions import CheckAndSetError
+
 
 
 MemcacheServer = collections.namedtuple('MemcacheServer', ('hostname', 'port'))
@@ -209,18 +211,37 @@ class BloomFilter(object):
             yield mmh3.hash(encoded_value, seed=seed) % self.size()
 
     def _load_bit_array(self):
-        bit_string = self.memcache.get(self.key)
+        bit_string, self._cas = self.memcache.gets(self.key)
         if bit_string is None:
             self._bit_array = bitarray('0' * self.size())
+            self._store_bit_array()
         else:
             self._bit_array = bitarray()
             self._bit_array.frombytes(bit_string)
 
     def _store_bit_array(self):
-        if self._bit_array.any():
-            self.memcache.set(self.key, self._bit_array.tobytes())
+        bit_string = self._bit_array.tobytes()
+        if self._cas is None:
+            self.memcache.set(self.key, bit_string)
         else:
-            self.memcache.delete(self.key)
+            if not self.memcache.cas(self.key, bit_string, self._cas):
+                raise CheckAndSetError(memcache=self.memcache, key=self.key)
+        self._load_bit_array()
+
+    def _retry_check_and_set(num_tries=3):
+        def decorator(func):
+            @functools.wraps(func)
+            def wrapper(self, *args, **kwargs):
+                for try_num in xrange(num_tries):   # pragma: no cover
+                    try:
+                        return func(self, *args, **kwargs)
+                    except CheckAndSetError:
+                        if try_num < num_tries - 1:
+                            self._load_bit_array()
+                        else:
+                            raise
+            return wrapper
+        return decorator
 
     def add(self, value):
         '''Add an element to a BloomFilter.  O(k)
@@ -233,6 +254,7 @@ class BloomFilter(object):
         '''
         self.update({value})
 
+    @_retry_check_and_set()
     def update(self, *iterables):
         '''Populate a Bloom filter with the elements in iterables.  O(n * k)
 
@@ -242,7 +264,7 @@ class BloomFilter(object):
 
         Your elements can be of any type that can be dumped as JSON.
         '''
-        iterables, bit_offsets = tuple(iterables), set()
+        bit_offsets = set()
         for value in itertools.chain(*iterables):
             bit_offsets.update(self._bit_offsets(value))
         for bit_offset in bit_offsets:
@@ -261,6 +283,7 @@ class BloomFilter(object):
         bit_offsets = set(self._bit_offsets(value))
         return all(self._bit_array[bit_offset] for bit_offset in bit_offsets)
 
+    @_retry_check_and_set()
     def clear(self):
         '''Remove all elements from this Bloom filter.  O(m)
 

--- a/bloom/bloom.py
+++ b/bloom/bloom.py
@@ -1,7 +1,7 @@
 #-----------------------------------------------------------------------------#
 #   bloom.py                                                                  #
 #                                                                             #
-#   Copyright (c) 2017, Rajiv Bakulesh Shah, original author.                 #
+#   Copyright (c) 2017-2018, Rajiv Bakulesh Shah, original author.            #
 #   All rights reserved.                                                      #
 #-----------------------------------------------------------------------------#
 

--- a/bloom/exceptions.py
+++ b/bloom/exceptions.py
@@ -1,7 +1,7 @@
 #-----------------------------------------------------------------------------#
 #   exceptions.py                                                             #
 #                                                                             #
-#   Copyright (c) 2017, Rajiv Bakulesh Shah, original author.                 #
+#   Copyright (c) 2017-2018, Rajiv Bakulesh Shah, original author.            #
 #   All rights reserved.                                                      #
 #-----------------------------------------------------------------------------#
 

--- a/bloom/exceptions.py
+++ b/bloom/exceptions.py
@@ -6,7 +6,6 @@
 #-----------------------------------------------------------------------------#
 
 
-
 class BloomFilterException(Exception):
     def __init__(self, memcache=None, key=None, retriable=False):
         super(BloomFilterException, self).__init__()
@@ -20,7 +19,6 @@ class BloomFilterException(Exception):
             self.key,
             self.retriable,
         )
-
 
 
 class CheckAndSetError(BloomFilterException):

--- a/bloom/exceptions.py
+++ b/bloom/exceptions.py
@@ -1,0 +1,32 @@
+#-----------------------------------------------------------------------------#
+#   exceptions.py                                                             #
+#                                                                             #
+#   Copyright (c) 2017, Rajiv Bakulesh Shah, original author.                 #
+#   All rights reserved.                                                      #
+#-----------------------------------------------------------------------------#
+
+
+
+class BloomFilterException(Exception):
+    def __init__(self, memcache=None, key=None, retriable=False):
+        super(BloomFilterException, self).__init__()
+        self.memcache = memcache
+        self.key = key
+        self.retriable = retriable
+
+    def __repr__(self):     # pragma: no cover
+        return '<{} key={} retriable={}>'.format(
+            self.__class__.__name__,
+            self.key,
+            self.retriable,
+        )
+
+
+
+class CheckAndSetError(BloomFilterException):
+    def __init__(self, memcache=None, key=None):
+        super(CheckAndSetError, self).__init__(
+            memcache=memcache,
+            key=key,
+            retriable=True,
+        )

--- a/requirements-to-freeze.txt
+++ b/requirements-to-freeze.txt
@@ -1,7 +1,7 @@
 #-----------------------------------------------------------------------------#
 #   requirements-to-freeze.txt                                                #
 #                                                                             #
-#   Copyright © 2017, Rajiv Bakulesh Shah, original author.                   #
+#   Copyright (c) 2017-2018, Rajiv Bakulesh Shah, original author.            #
 #   All rights reserved.                                                      #
 #-----------------------------------------------------------------------------#
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,6 @@
 #-----------------------------------------------------------------------------#
 #   __init__.py                                                               #
 #                                                                             #
-#   Copyright (c) 2017, Rajiv Bakulesh Shah, original author.                 #
+#   Copyright (c) 2017-2018, Rajiv Bakulesh Shah, original author.            #
 #   All rights reserved.                                                      #
 #-----------------------------------------------------------------------------#

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -221,12 +221,12 @@ class RecentlyConsumedTests(unittest.TestCase):
             return round(number, ndigits)
 
     def test_zero_false_negatives(self):
-        'Ensure that we produce zero false negatives.'
+        'Ensure that we produce zero false negatives'
         for seen_link in self.seen_links:
             assert seen_link in self.recently_consumed
 
     def test_acceptable_false_positives(self):
-        'Ensure that we produce false positives at an acceptable rate.'
+        'Ensure that we produce false positives at an acceptable rate'
         acceptable, actual = self.recently_consumed.false_positives, 0
 
         for unseen_link in self.unseen_links:

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -1,7 +1,7 @@
 #-----------------------------------------------------------------------------#
 #   test_bloom.py                                                             #
 #                                                                             #
-#   Copyright (c) 2017, Rajiv Bakulesh Shah, original author.                 #
+#   Copyright (c) 2017-2018, Rajiv Bakulesh Shah, original author.            #
 #   All rights reserved.                                                      #
 #-----------------------------------------------------------------------------#
 

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -6,14 +6,12 @@
 #-----------------------------------------------------------------------------#
 
 
-
 import math
 import random
 import string
 import unittest
 
 from bloom import BloomFilter
-
 
 
 class BloomFilterTests(unittest.TestCase):
@@ -163,7 +161,6 @@ class BloomFilterTests(unittest.TestCase):
         assert repr(dilberts) == '<BloomFilter key=dilberts>'
 
 
-
 class RecentlyConsumedTests(unittest.TestCase):
     "Simulate reddit's recently consumed problem to test our Bloom filter."
 
@@ -238,7 +235,6 @@ class RecentlyConsumedTests(unittest.TestCase):
         assert actual <= acceptable, message
 
 
-
 class StoreBitArrayTests(unittest.TestCase):
     'Whenever we change a BloomFilter, ensure that we Memcache our changes.'
 
@@ -272,7 +268,6 @@ class StoreBitArrayTests(unittest.TestCase):
         self.dilberts.clear()
         office_space = BloomFilter(key='dilberts')
         assert office_space._bit_array == self.dilberts._bit_array
-
 
 
 class CheckAndSetTests(unittest.TestCase):

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -199,9 +199,9 @@ class RecentlyConsumedTests(unittest.TestCase):
 
     @staticmethod
     def random_fullname(prefix='t3_', size=6):
-        alphabet, id36 = string.digits + string.ascii_lowercase, []
+        alphabet36, id36 = string.digits + string.ascii_lowercase, []
         for _ in xrange(size):
-            id36.append(random.choice(alphabet))
+            id36.append(random.choice(alphabet36))
         return prefix + ''.join(id36)
 
     @staticmethod

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -6,12 +6,10 @@
 #-----------------------------------------------------------------------------#
 
 
-
 import doctest
 import importlib
 import os
 import unittest
-
 
 
 class DoctestTests(unittest.TestCase):

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -1,7 +1,7 @@
 #-----------------------------------------------------------------------------#
 #   test_doctests.py                                                          #
 #                                                                             #
-#   Copyright (c) 2017, Rajiv Bakulesh Shah, original author.                 #
+#   Copyright (c) 2017-2018, Rajiv Bakulesh Shah, original author.            #
 #   All rights reserved.                                                      #
 #-----------------------------------------------------------------------------#
 


### PR DESCRIPTION
One of @reddit's use-cases is to allow multiple threads to update a Bloom filter.  Account for this by using [Memcache's `cas` (Check And Set) command](https://github.com/memcached/memcached/wiki/Commands#cas) to implement [optimistic concurrency control](https://en.wikipedia.org/wiki/Optimistic_concurrency_control) with a retry decorator.

As of this PR, one thread's changes to a `BloomFilter` will never stomp another thread's changes to the `BloomFilter`.  Instead, all `BloomFilter` updates will get merged together across threads.