### PR TITLE
Design/implement/test MemLock

### DIFF
--- a/bloom/__init__.py
+++ b/bloom/__init__.py
@@ -7,8 +7,14 @@
 
 
 from .bloom import BloomFilter
+from .contexttimer import ContextTimer
 from .exceptions import BloomFilterException
 from .exceptions import CheckAndSetError
 
 
-__all__ = ['BloomFilter', 'BloomFilterException', 'CheckAndSetError']
+__all__ = [
+    'BloomFilter',
+    'BloomFilterException',
+    'CheckAndSetError',
+    'ContextTimer',
+]

--- a/bloom/__init__.py
+++ b/bloom/__init__.py
@@ -8,8 +8,12 @@
 
 from .bloom import BloomFilter
 from .contexttimer import ContextTimer
-from .exceptions import BloomFilterException
-from .exceptions import CheckAndSetError
+from .exceptions import (
+    BloomFilterException,
+    CheckAndSetError,
+    ReleaseUnlockedLock,
+)
+from .memlock import MemLock
 
 
 __all__ = [
@@ -17,4 +21,6 @@ __all__ = [
     'BloomFilterException',
     'CheckAndSetError',
     'ContextTimer',
+    'MemLock',
+    'ReleaseUnlockedLock',
 ]

--- a/bloom/base.py
+++ b/bloom/base.py
@@ -1,0 +1,61 @@
+#-----------------------------------------------------------------------------#
+#   base.py                                                                   #
+#                                                                             #
+#   Copyright (c) 2017-2018, Rajiv Bakulesh Shah, original author.            #
+#   All rights reserved.                                                      #
+#-----------------------------------------------------------------------------#
+
+
+import collections
+import doctest
+import functools
+import random
+import string
+import sys
+
+from pymemcache.client.base import Client
+
+
+MemcacheServer = collections.namedtuple('MemcacheServer', ('hostname', 'port'))
+
+
+class Base(object):
+    _DEFAULT_MEMCACHE_SERVER = MemcacheServer(hostname='localhost', port=11211)
+    _RANDOM_KEY_PREFIX = 'base:'
+    _RANDOM_KEY_CHARS = ''.join((string.digits, string.ascii_lowercase))
+    _RANDOM_KEY_LENGTH = 16
+
+    def __init__(self, memcache=None, key=None):
+        self.memcache = memcache or Client(
+            self._DEFAULT_MEMCACHE_SERVER,
+            connect_timeout=1,
+            timeout=1,
+        )
+        self.key = key or self._random_key()
+
+    def __del__(self):  # pragma: no cover
+        if self.key.startswith(self._RANDOM_KEY_PREFIX):
+            self.memcache.delete(self.key)
+
+    @classmethod
+    def _random_key(cls):
+        random_char = functools.partial(random.choice, cls._RANDOM_KEY_CHARS)
+        suffix = ''.join(random_char() for _ in xrange(cls._RANDOM_KEY_LENGTH))
+        random_key = ''.join((cls._RANDOM_KEY_PREFIX, suffix))
+        return random_key
+
+    def __repr__(self):
+        'Return the string representation of an instance of our subclass.'
+        return '<{} key={}>'.format(self.__class__.__name__, self.key)
+
+
+def run_doctests():         # pragma: no cover
+    results = doctest.testmod()
+    sys.exit(bool(results.failed))
+
+if __name__ == '__main__':  # pragma: no cover
+    # Run the doctests in this module with:
+    #   $ source venv/bin/activate
+    #   $ python -m bloom.base
+    #   $ deactivate
+    run_doctests()

--- a/bloom/contexttimer.py
+++ b/bloom/contexttimer.py
@@ -1,0 +1,79 @@
+#-----------------------------------------------------------------------------#
+#   contexttimer.py                                                           #
+#                                                                             #
+#   Copyright (c) 2017-2018, Rajiv Bakulesh Shah, original author.            #
+#   All rights reserved.                                                      #
+#-----------------------------------------------------------------------------#
+'Measure the execution time of small code snippets.'
+
+
+import timeit
+
+
+class ContextTimer(object):
+    '''Measure the execution time of small code snippets.
+
+    Note that ContextTimer measures wall (real-world) time, not CPU time; and
+    that elapsed() returns time in milliseconds.
+
+    You can use ContextTimer stand-alone...
+
+        >>> import time
+        >>> timer = ContextTimer()
+        >>> timer.start()
+        >>> time.sleep(0.1)
+        >>> 100 <= timer.elapsed() < 200
+        True
+        >>> timer.stop()
+        >>> time.sleep(0.1)
+        >>> 100 <= timer.elapsed() < 200
+        True
+
+    ...or as a context manager:
+
+        >>> tests = []
+        >>> with ContextTimer() as timer:
+        ...     time.sleep(0.1)
+        ...     tests.append(100 <= timer.elapsed() < 200)
+        >>> time.sleep(0.1)
+        >>> tests.append(100 <= timer.elapsed() < 200)
+        >>> tests
+        [True, True]
+    '''
+
+    def __init__(self):
+        super(ContextTimer, self).__init__()
+        self._started = None
+        self._stopped = None
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.stop()
+
+    def start(self):
+        if self._stopped:
+            raise RuntimeError('timer has already been stopped')
+        elif self._started:
+            raise RuntimeError('timer has already been started')
+        else:
+            self._started = timeit.default_timer()
+
+    def stop(self):
+        if self._stopped:
+            raise RuntimeError('timer has already been stopped')
+        elif self._started:
+            self._stopped = timeit.default_timer()
+        else:
+            raise RuntimeError("timer hasn't yet been started")
+
+    def elapsed(self):
+        try:
+            value = (self._stopped or timeit.default_timer()) - self._started
+        except TypeError:
+            raise RuntimeError("timer hasn't yet been started")
+        else:
+            value = round(value * 1000) # rounded to the nearest millisecond
+            return value

--- a/bloom/exceptions.py
+++ b/bloom/exceptions.py
@@ -28,3 +28,12 @@ class CheckAndSetError(BloomFilterException):
             key=key,
             retriable=True,
         )
+
+
+class ReleaseUnlockedLock(BloomFilterException):
+    def __init__(self, memcache=None, key=None):
+        super(ReleaseUnlockedLock, self).__init__(
+            memcache=memcache,
+            key=key,
+            retriable=False,
+        )

--- a/bloom/memlock.py
+++ b/bloom/memlock.py
@@ -1,0 +1,137 @@
+#-----------------------------------------------------------------------------#
+#   memlock.py                                                                #
+#                                                                             #
+#   Copyright (c) 2017-2018, Rajiv Bakulesh Shah, original author.            #
+#   All rights reserved.                                                      #
+#-----------------------------------------------------------------------------#
+
+
+import random
+import time
+
+from .base import Base, run_doctests
+from .contexttimer import ContextTimer
+from .exceptions import ReleaseUnlockedLock
+
+
+class MemLock(Base):
+    '''Memcache-backed lock with an API similar to Python's threading.Lock.
+
+    This algorithm safely and reliably provides a mutually-exclusive locking
+    primitive to protect a resource shared across threads, processes, and even
+    machines.
+
+    Usage:
+
+        >>> printer_lock = MemLock(key='printer')
+        >>> printer_lock.locked()
+        False
+        >>> printer_lock.acquire()
+        True
+        >>> printer_lock.locked()
+        True
+        >>> # Critical section - print stuff here.
+        >>> printer_lock.release()
+        >>> printer_lock.locked()
+        False
+
+    MemLocks time out (by default, after 1 second).  You should take care to
+    ensure that your critical section completes well within the timeout.  The
+    reasons that MemLocks time out are to preserve "liveness" and to avoid
+    deadlocks (in the event that a process dies inside a critical section
+    before it releases its lock).
+
+        >>> printer_lock.acquire()
+        True
+        >>> printer_lock.locked()
+        True
+        >>> # Critical section - print stuff here.
+        >>> time.sleep(1)
+        >>> printer_lock.locked()
+        False
+
+    You can use a MemLock as a context manager:
+
+        >>> states = []
+        >>> with MemLock(key='printer') as printer_lock:
+        ...     states.append(printer_lock.locked())
+        ...     # Critical section - print stuff here.
+        >>> states.append(printer_lock.locked())
+        >>> states
+        [True, False]
+    '''
+
+    _RANDOM_KEY_PREFIX = 'memlock:'
+    _AUTO_RELEASE_TIME = 1
+    _RETRY_DELAY = 0.2
+
+    def __init__(self, memcache=None, key=None,
+                 auto_release_time=_AUTO_RELEASE_TIME):
+        super(MemLock, self).__init__(memcache=memcache, key=key)
+        self.auto_release_time = auto_release_time
+
+        # Set self._value to a random string, unique to this MemLock instance.
+        # Later when we acquire this lock, in Memcache, we'll set self.key to
+        # self._value.
+        #
+        # We need for self._value to be unique for each MemLock instance
+        # because two machines may instantiate MemLocks on the same Memcache
+        # key, and self._value is the only way that we can know which machine
+        # holds the lock.
+        self._value = self._random_key()
+
+    def _memcache_add(self):
+        return self.memcache.add(
+            self.key,
+            self._value,
+            expire=self.auto_release_time,
+            noreply=False,
+        )
+
+    def acquire(self, blocking=True, timeout=-1):
+        'Lock the lock.'
+        if blocking:
+            with ContextTimer() as timer:
+                while timeout == -1 or timer.elapsed() / 1000 < timeout:
+                    if self._memcache_add():
+                        return True
+                    else:
+                        time.sleep(random.uniform(0, self._RETRY_DELAY))
+            return False
+        elif timeout == -1:
+            return self._memcache_add()
+        else:
+            raise ValueError("can't specify a timeout for a non-blocking call")
+
+    def locked(self):
+        'Whether the lock is locked.'
+        return bool(self.memcache.get(self.key))
+
+    def release(self):
+        'Unlock the lock.'
+        if not self.memcache.delete(self.key, noreply=False):
+            raise ReleaseUnlockedLock(memcache=self.memcache, key=self.key)
+
+    def __enter__(self):
+        'Using a MemLock as a context manager, enter the critical section.'
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        'Using a MemLock as a context manager, exit the critical section.'
+        self.release()
+
+    def __repr__(self):
+        return '<{} key={} locked={}>'.format(
+            self.__class__.__name__,
+            self.key,
+            self.locked(),
+        )
+
+
+if __name__ == '__main__':  # pragma: no cover
+    # Run the doctests in this module with:
+    #   $ source venv/bin/activate
+    #   $ python -m bloom.memlock
+    #   $ deactivate
+    run_doctests()

--- a/tests/test_contexttimer.py
+++ b/tests/test_contexttimer.py
@@ -1,0 +1,60 @@
+#-----------------------------------------------------------------------------#
+#   test_contexttimer.py                                                      #
+#                                                                             #
+#   Copyright (c) 2017-2018, Rajiv Bakulesh Shah, original author.            #
+#   All rights reserved.                                                      #
+#-----------------------------------------------------------------------------#
+
+
+import time
+import unittest
+
+from bloom import ContextTimer
+
+
+class ContextTimerTests(unittest.TestCase):
+    ACCURACY = 50.0     # in milliseconds
+
+    def setUp(self):
+        super(ContextTimerTests, self).setUp()
+        self.timer = ContextTimer()
+
+    def _confirm_elapsed(self, expected):
+        got = round(self.timer.elapsed() / self.ACCURACY) * self.ACCURACY
+        assert got == expected, '{} != {}'.format(got, expected)
+
+    def test_start_stop_and_elapsed(self):
+        # timer hasn't been started
+        with self.assertRaises(RuntimeError):
+            self.timer.elapsed()
+        with self.assertRaises(RuntimeError):
+            self.timer.stop()
+
+        # timer has been started but not stopped
+        self.timer.start()
+        with self.assertRaises(RuntimeError):
+            self.timer.start()
+        time.sleep(0.1)
+        self._confirm_elapsed(1*100)
+        self.timer.stop()
+
+        # timer has been stopped
+        with self.assertRaises(RuntimeError):
+            self.timer.start()
+        time.sleep(0.1)
+        self._confirm_elapsed(1*100)
+        with self.assertRaises(RuntimeError):
+            self.timer.stop()
+
+    def test_context_manager(self):
+        with self.timer:
+            self._confirm_elapsed(0)
+            for iteration in range(1, 3):
+                time.sleep(0.1)
+                self._confirm_elapsed(iteration*100)
+            self._confirm_elapsed(iteration*100)
+        time.sleep(0.1)
+        self._confirm_elapsed(iteration*100)
+
+        with self.assertRaises(RuntimeError), self.timer:
+            pass

--- a/tests/test_memlock.py
+++ b/tests/test_memlock.py
@@ -1,0 +1,125 @@
+#-----------------------------------------------------------------------------#
+#   test_memlock.py                                                           #
+#                                                                             #
+#   Copyright (c) 2017-2018, Rajiv Bakulesh Shah, original author.            #
+#   All rights reserved.                                                      #
+#-----------------------------------------------------------------------------#
+
+
+import time
+import unittest
+
+from bloom import ContextTimer, MemLock, ReleaseUnlockedLock
+
+
+class MemLockTests(unittest.TestCase):
+    def setUp(self):
+        super(MemLockTests, self).setUp()
+        self.memlock = MemLock(key='printer')
+        self._release()
+
+    def tearDown(self):
+        self._release()
+        super(MemLockTests, self).tearDown()
+
+    def _release(self):
+        try:
+            self.memlock.release()
+        except ReleaseUnlockedLock:
+            pass
+
+    def test_acquire_and_time_out(self):
+        assert not self.memlock.locked()
+        assert self.memlock.acquire()
+        assert self.memlock.locked()
+        time.sleep(self.memlock.auto_release_time)
+        assert not self.memlock.locked()
+
+    def test_acquire_same_lock_twice_blocking_without_timeout(self):
+        with ContextTimer() as timer:
+            assert not self.memlock.locked()
+            assert self.memlock.acquire()
+            assert self.memlock.locked()
+            assert self.memlock.acquire()
+            assert self.memlock.locked()
+            assert timer.elapsed() > self.memlock.auto_release_time
+
+    def test_acquire_same_lock_twice_blocking_with_timeout(self):
+        assert not self.memlock.locked()
+        assert self.memlock.acquire()
+        assert self.memlock.locked()
+        assert not self.memlock.acquire(timeout=0)
+        assert self.memlock.locked()
+
+    def test_acquire_same_lock_twice_non_blocking_without_timeout(self):
+        assert not self.memlock.locked()
+        assert self.memlock.acquire()
+        assert self.memlock.locked()
+        assert not self.memlock.acquire(blocking=False)
+        assert self.memlock.locked()
+        time.sleep(self.memlock.auto_release_time)
+        assert not self.memlock.locked()
+
+    def test_acquire_same_lock_twice_non_blocking_with_timeout(self):
+        assert not self.memlock.locked()
+        assert self.memlock.acquire()
+        assert self.memlock.locked()
+        with self.assertRaises(ValueError):
+            self.memlock.acquire(blocking=False, timeout=0)
+        assert self.memlock.locked()
+
+    def test_acquire_then_release(self):
+        assert not self.memlock.locked()
+        assert self.memlock.acquire()
+        assert self.memlock.locked()
+        self.memlock.release()
+        assert not self.memlock.locked()
+
+    def test_release_unlocked_lock(self):
+        assert not self.memlock.locked()
+        with self.assertRaises(ReleaseUnlockedLock):
+            self.memlock.release()
+
+    def test_releaseunlockedlock_repr(self):
+        assert not self.memlock.locked()
+        try:
+            self.memlock.release()
+        except ReleaseUnlockedLock as err:
+            assert repr(err) == (
+                '<ReleaseUnlockedLock key=printer retriable=False>'
+            )
+
+    def test_release_same_lock_twice(self):
+        assert not self.memlock.locked()
+        assert self.memlock.acquire()
+        assert self.memlock.locked()
+        self.memlock.release()
+        assert not self.memlock.locked()
+        with self.assertRaises(ReleaseUnlockedLock):
+            self.memlock.release()
+        assert not self.memlock.locked()
+
+    def test_context_manager(self):
+        assert not self.memlock.locked()
+        with self.memlock:
+            assert self.memlock.locked()
+        assert not self.memlock.locked()
+
+    def test_context_manager_time_out_before_exit(self):
+        assert not self.memlock.locked()
+        with self.assertRaises(ReleaseUnlockedLock), self.memlock:
+            assert self.memlock.locked()
+            time.sleep(self.memlock.auto_release_time)
+            assert not self.memlock.locked()
+        assert not self.memlock.locked()
+
+    def test_context_manager_release_before_exit(self):
+        assert not self.memlock.locked()
+        with self.assertRaises(ReleaseUnlockedLock), self.memlock:
+            assert self.memlock.locked()
+            self.memlock.release()
+            assert not self.memlock.locked()
+        assert not self.memlock.locked()
+
+    def test_repr(self):
+        assert repr(self.memlock) == '<MemLock key=printer locked=False>'


### PR DESCRIPTION
`MemLock` is a Memcache-backed lock with an API similar to Python&rsquo;s [`threading.Lock`](https://docs.python.org/2/library/threading.html#lock-objects).  The main differences to `threading.Lock` are that (1) `MemLock`s time out to preserve &ldquo;liveness&rdquo; (in the event that a process dies in the critical section while holding a lock), and (2) a `MemLock` instance is not enough to uniquely identify a lock (as `MemLock` is backed by Memcache, and multiple machines may instantiate `MemLock`s pointed at the same Memcache key).  To address (2), each `MemLock` instance has a unique attribute `_value` which we check/set in Memcache using [`add`](https://github.com/memcached/memcached/wiki/Commands#add).

Please note that `MemLock` does not depend on [`cas`](https://github.com/memcached/memcached/wiki/Commands#cas).