### PR TITLE
Implement Memcached RecentlyConsumed as set/deque

### DIFF
--- a/bloom/__init__.py
+++ b/bloom/__init__.py
@@ -7,6 +7,7 @@
 
 
 from .bloom import BloomFilter
+from .consumed import RecentlyConsumed
 from .contexttimer import ContextTimer
 from .exceptions import (
     BloomFilterException,
@@ -22,5 +23,6 @@ __all__ = [
     'CheckAndSetError',
     'ContextTimer',
     'MemLock',
+    'RecentlyConsumed',
     'ReleaseUnlockedLock',
 ]

--- a/bloom/base.py
+++ b/bloom/base.py
@@ -21,7 +21,7 @@ MemcacheServer = collections.namedtuple('MemcacheServer', ('hostname', 'port'))
 
 class Base(object):
     _DEFAULT_MEMCACHE_SERVER = MemcacheServer(hostname='localhost', port=11211)
-    _RANDOM_KEY_PREFIX = 'base:'
+    _RANDOM_KEY_PREFIX = 'tmp:base:'
     _RANDOM_KEY_CHARS = ''.join((string.digits, string.ascii_lowercase))
     _RANDOM_KEY_LENGTH = 16
 

--- a/bloom/bloom.py
+++ b/bloom/bloom.py
@@ -99,7 +99,7 @@ class BloomFilter(Base):
         >>> dilberts.clear()
     '''
 
-    _RANDOM_KEY_PREFIX = 'bloom:'
+    _RANDOM_KEY_PREFIX = 'tmp:bloom:'
 
     def __init__(self, iterable=frozenset(), memcache=None, key=None,
                  num_values=1000, false_positives=0.001):

--- a/bloom/consumed.py
+++ b/bloom/consumed.py
@@ -34,6 +34,12 @@ class RecentlyConsumed(Base):
     _RANDOM_KEY_PREFIX = 'tmp:consumed:'
     _MAXLEN = 1000
 
+    # If _NOREPLY is False, then we wait for each Memcache command to complete
+    # before moving on to the next line of code.  _NOREPLY should be False when
+    # running our unit tests (to make our tests run deterministically), but
+    # True on production (so that our code runs faster).
+    _NOREPLY = True
+
     def __init__(self, memcache=None, key=None, maxlen=_MAXLEN):
         super(RecentlyConsumed, self).__init__(memcache=memcache, key=key)
         self._maxlen = maxlen
@@ -63,9 +69,9 @@ class RecentlyConsumed(Base):
         if self._set:
             list_ = list(self._deque)
             string = json.dumps(list_)
-            self.memcache.set(self.key, string, noreply=True)
+            self.memcache.set(self.key, string, noreply=self._NOREPLY)
         else:
-            self.memcache.delete(self.key)
+            self.memcache.delete(self.key, noreply=self._NOREPLY)
 
     def _prune_to_maxlen(self):
         while self.maxlen is not None and len(self) > self.maxlen:

--- a/bloom/consumed.py
+++ b/bloom/consumed.py
@@ -31,7 +31,7 @@ class RecentlyConsumed(Base):
     instances/accesses.  A good choice for such a lock is .memlock.MemLock.
     '''
 
-    _RANDOM_KEY_PREFIX = 'consumed:'
+    _RANDOM_KEY_PREFIX = 'tmp:consumed:'
     _MAXLEN = 1000
 
     def __init__(self, memcache=None, key=None, maxlen=_MAXLEN):

--- a/bloom/consumed.py
+++ b/bloom/consumed.py
@@ -1,0 +1,123 @@
+#-----------------------------------------------------------------------------#
+#   consumed.py                                                               #
+#                                                                             #
+#   Copyright (c) 2017-2018, Rajiv Bakulesh Shah, original author.            #
+#   All rights reserved.                                                      #
+#-----------------------------------------------------------------------------#
+
+
+import collections
+import json
+
+from .base import Base, run_doctests
+
+
+class RecentlyConsumed(Base):
+    '''Memcache-backed data structure to track recently consumed links.
+
+    On the consumer side, we want a data structure similar to a
+    collections.deque (as we're appending a user's new consumed links to the
+    right and popping old consumed links from the left).  But on the listing
+    service side, we want a data structure similar to a set (as we're testing
+    many candidate links for membership within the user's RecentlyConsumed).
+
+    Therefore, RecentlyConsumed (persisted in Memcache) implements a subset of
+    the collections.deque API and a subset of the set API.  As such, please
+    note that RecentlyConsumed silently ignores duplicate values during
+    append() and extend().
+
+    Further, please note that RecentlyConsumed is neither thread-safe nor safe
+    to use across instances.  Please lock around your RecentlyConsumed
+    instances/accesses.  A good choice for such a lock is .memlock.MemLock.
+    '''
+
+    _RANDOM_KEY_PREFIX = 'consumed:'
+    _MAXLEN = 1000
+
+    def __init__(self, memcache=None, key=None, maxlen=_MAXLEN):
+        super(RecentlyConsumed, self).__init__(memcache=memcache, key=key)
+        self._maxlen = maxlen
+        self._load_from_memcache()
+
+    @property
+    def maxlen(self):
+        return self._maxlen
+
+    @maxlen.setter
+    def maxlen(self, value):
+        message = "attribute 'maxlen' of '{}' objects is not writable"
+        message = message.format(self.__class__.__name__)
+        raise AttributeError(message)
+
+    def _load_from_memcache(self):
+        string = self.memcache.get(self.key, default='[]')
+        list_ = json.loads(string)
+        if self.maxlen is not None and len(list_) > self.maxlen:
+            message = 'persistent {} beyond its maximum size'
+            message = message.format(self.__class__.__name__)
+            raise IndexError(message)
+        self._deque = collections.deque(list_)
+        self._set = set(list_)
+
+    def _store_to_memcache(self):
+        if self._set:
+            list_ = list(self._deque)
+            string = json.dumps(list_)
+            self.memcache.set(self.key, string, noreply=True)
+        else:
+            self.memcache.delete(self.key)
+
+    def _prune_to_maxlen(self):
+        while self.maxlen is not None and len(self) > self.maxlen:
+            value = self._deque.popleft()
+            self._set.remove(value)
+
+    def __len__(self):
+        'Return the number of items in the RecentlyConsumed.'
+        return len(self._set)
+
+    def __contains__(self, value):
+        'rc.__contains__(element) <==> element in rc.'
+        return unicode(value) in self._set
+
+    def append(self, value):
+        'Add an element to the right side of the RecentlyConsumed.'
+        value = unicode(value)
+        if value not in self:
+            self._deque.append(value)
+            self._set.add(value)
+            self._prune_to_maxlen()
+            self._store_to_memcache()
+
+    def extend(self, values):
+        'Extend a RecentlyConsumed by appending elements from the iterable.'
+        values = tuple(unicode(value) for value in values if value not in self)
+        if values:
+            self._deque.extend(values)
+            self._set.update(values)
+            self._prune_to_maxlen()
+            self._store_to_memcache()
+
+    def clear(self):
+        'Remove all elements from the RecentlyConsumed.'
+        self._deque.clear()
+        self._set.clear()
+        self._store_to_memcache()
+
+    def __repr__(self):
+        'Return the string representation of the RecentlyConsumed data struct.'
+        repr = self.__class__.__name__ + '('
+        repr += str(list(self._deque))
+        repr += ', key={}'.format(self.key)
+        if self.maxlen is not None:
+            repr += ', ' + 'maxlen={}'.format(self.maxlen)
+        repr += ')'
+        return repr
+
+
+if __name__ == '__main__':  # pragma: no cover
+    # Run the doctests in this module with:
+    #   $ source venv/bin/activate
+    #   $ python -m bloom.consumed
+    #   $ deactivate
+    run_doctests()

--- a/bloom/memlock.py
+++ b/bloom/memlock.py
@@ -61,7 +61,7 @@ class MemLock(Base):
         [True, False]
     '''
 
-    _RANDOM_KEY_PREFIX = 'memlock:'
+    _RANDOM_KEY_PREFIX = 'tmp:memlock:'
     _AUTO_RELEASE_TIME = 1
     _RETRY_DELAY = 0.2
 

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -161,7 +161,7 @@ class BloomFilterTests(unittest.TestCase):
         assert repr(dilberts) == '<BloomFilter key=dilberts>'
 
 
-class RecentlyConsumedTests(unittest.TestCase):
+class RecentlyConsumedSimulationTests(unittest.TestCase):
     "Simulate reddit's recently consumed problem to test our Bloom filter."
 
     def setUp(self):

--- a/tests/test_consumed.py
+++ b/tests/test_consumed.py
@@ -1,0 +1,169 @@
+#-----------------------------------------------------------------------------#
+#   test_consumed.py                                                          #
+#                                                                             #
+#   Copyright (c) 2017-2018, Rajiv Bakulesh Shah, original author.            #
+#   All rights reserved.                                                      #
+#-----------------------------------------------------------------------------#
+
+
+import unittest
+
+from bloom import RecentlyConsumed
+
+
+class RecentlyConsumedTests(unittest.TestCase):
+    def setUp(self):
+        super(RecentlyConsumedTests, self).setUp()
+
+        # Wait for each Memcache command to complete before moving on to the
+        # next line of code.  This makes our tests run deterministically.
+        RecentlyConsumed._NOREPLY = False
+
+        self.consumed = RecentlyConsumed(key='consumed:rajiv', maxlen=10)
+
+    def tearDown(self):
+        self.consumed.clear()
+        RecentlyConsumed._NOREPLY = True
+        super(RecentlyConsumedTests, self).tearDown()
+
+    def test_maxlen_is_not_writable(self):
+        with self.assertRaises(AttributeError):
+            self.consumed.maxlen = 100
+
+    def test_memcached_list_does_not_exceed_maxlen(self):
+        self.consumed.extend(('t3_1', 't3_2', 't3_3', 't3_4', 't3_5', 't3_6'))
+        with self.assertRaises(IndexError):
+            RecentlyConsumed(key='consumed:rajiv', maxlen=5)
+
+    def test_typical_usage(self):
+        assert len(self.consumed) == 0
+        assert 't3_1' not in self.consumed
+        assert 't3_2' not in self.consumed
+        assert 't3_3' not in self.consumed
+        assert 't3_4' not in self.consumed
+        assert 't3_5' not in self.consumed
+
+        self.consumed.append('t3_1')
+        assert len(self.consumed) == 1
+        assert 't3_1' in self.consumed
+        assert 't3_2' not in self.consumed
+        assert 't3_3' not in self.consumed
+        assert 't3_4' not in self.consumed
+        assert 't3_5' not in self.consumed
+
+        self.consumed.extend(('t3_1', 't3_2', 't3_3'))
+        assert len(self.consumed) == 3
+        assert 't3_1' in self.consumed
+        assert 't3_2' in self.consumed
+        assert 't3_3' in self.consumed
+        assert 't3_4' not in self.consumed
+        assert 't3_5' not in self.consumed
+
+        self.consumed.append('t3_3')
+        assert len(self.consumed) == 3
+        assert 't3_1' in self.consumed
+        assert 't3_2' in self.consumed
+        assert 't3_3' in self.consumed
+        assert 't3_4' not in self.consumed
+        assert 't3_5' not in self.consumed
+
+        self.consumed.append('t3_4')
+        assert len(self.consumed) == 4
+        assert 't3_1' in self.consumed
+        assert 't3_2' in self.consumed
+        assert 't3_3' in self.consumed
+        assert 't3_4' in self.consumed
+        assert 't3_5' not in self.consumed
+
+        self.consumed.extend(('t3_3', 't3_4'))
+        assert len(self.consumed) == 4
+        assert 't3_1' in self.consumed
+        assert 't3_2' in self.consumed
+        assert 't3_3' in self.consumed
+        assert 't3_4' in self.consumed
+        assert 't3_5' not in self.consumed
+
+    def test_pruning_to_maxlen(self):
+        self.consumed.extend(('t3_1', 't3_2', 't3_3', 't3_4', 't3_5'))
+        self.consumed.extend(('t3_6', 't3_7', 't3_8', 't3_9', 't3_10'))
+        assert len(self.consumed) == 10
+        assert 't3_1' in self.consumed
+        assert 't3_2' in self.consumed
+        assert 't3_3' in self.consumed
+        assert 't3_4' in self.consumed
+        assert 't3_5' in self.consumed
+        assert 't3_6' in self.consumed
+        assert 't3_7' in self.consumed
+        assert 't3_8' in self.consumed
+        assert 't3_9' in self.consumed
+        assert 't3_10' in self.consumed
+        assert 't3_11' not in self.consumed
+        assert 't3_12' not in self.consumed
+        assert 't3_13' not in self.consumed
+        assert 't3_14' not in self.consumed
+        assert 't3_15' not in self.consumed
+
+        self.consumed.append('t3_11')
+        assert len(self.consumed) == 10
+        assert 't3_1' not in self.consumed
+        assert 't3_2' in self.consumed
+        assert 't3_3' in self.consumed
+        assert 't3_4' in self.consumed
+        assert 't3_5' in self.consumed
+        assert 't3_6' in self.consumed
+        assert 't3_7' in self.consumed
+        assert 't3_8' in self.consumed
+        assert 't3_9' in self.consumed
+        assert 't3_10' in self.consumed
+        assert 't3_11' in self.consumed
+        assert 't3_12' not in self.consumed
+        assert 't3_13' not in self.consumed
+        assert 't3_14' not in self.consumed
+        assert 't3_15' not in self.consumed
+
+        self.consumed.extend(('t3_12', 't3_13', 't3_14', 't3_15'))
+        assert len(self.consumed) == 10
+        assert 't3_1' not in self.consumed
+        assert 't3_2' not in self.consumed
+        assert 't3_3' not in self.consumed
+        assert 't3_4' not in self.consumed
+        assert 't3_5' not in self.consumed
+        assert 't3_6' in self.consumed
+        assert 't3_7' in self.consumed
+        assert 't3_8' in self.consumed
+        assert 't3_9' in self.consumed
+        assert 't3_10' in self.consumed
+        assert 't3_11' in self.consumed
+        assert 't3_12' in self.consumed
+        assert 't3_13' in self.consumed
+        assert 't3_14' in self.consumed
+        assert 't3_15' in self.consumed
+
+    def test_clear(self):
+        self.consumed.extend(('t3_1', 't3_2', 't3_3'))
+        self.consumed.clear()
+        assert len(self.consumed) == 0
+        assert 't3_1' not in self.consumed
+        assert 't3_2' not in self.consumed
+        assert 't3_3' not in self.consumed
+        assert repr(self.consumed) == (
+            "RecentlyConsumed([], key=consumed:rajiv, maxlen=10)"
+        )
+
+    def test_repr(self):
+        assert repr(self.consumed) == (
+            "RecentlyConsumed([], key=consumed:rajiv, maxlen=10)"
+        )
+
+    def test_repr_when_maxlen_is_none(self):
+        consumed2 = RecentlyConsumed(key='consumed:rajiv', maxlen=None)
+        assert repr(consumed2) == "RecentlyConsumed([], key=consumed:rajiv)"
+
+    def test_persistence(self):
+        'Ensure that RecentlyConsumed gets persisted in Memcache'
+        self.consumed.extend(('t3_1', 't3_2', 't3_3'))
+        consumed2 = RecentlyConsumed(key='consumed:rajiv', maxlen=10)
+        assert repr(consumed2) == (
+            "RecentlyConsumed([u't3_1', u't3_2', u't3_3'], "
+            "key=consumed:rajiv, maxlen=10)"
+        )


### PR DESCRIPTION
On the consumer side, we want a data structure similar to a
`collections.deque` (as we're appending a user's new consumed links to
the right and popping old consumed links from the left).  But on the
listing service side, we want a data structure similar to a `set` (as
we're testing many candidate links for membership within the user's
`RecentlyConsumed`).

Therefore, `RecentlyConsumed` (persisted in Memcache) implements a
subset of the `collections.deque` API and a subset of the `set` API.  As
such, please note that `RecentlyConsumed` silently ignores duplicate
values during `append()` and `extend()`.

Further, please note that `RecentlyConsumed` is neither thread-safe nor
safe to use across instances.  Please lock around your
`RecentlyConsumed` instances/accesses.  A good choice for such a lock is
[`.memlock.MemLock`](https://github.com/brainix/bloom-filter/pull/17).